### PR TITLE
Fix shiny status on topscreen

### DIFF
--- a/arm9/source/manager.cpp
+++ b/arm9/source/manager.cpp
@@ -365,6 +365,7 @@ void drawPokemonInfo(const pksm::PKX &pkm) {
 	if(pkm.species() > pksm::Species::None && pkm.species() <= pksm::Species::Genesect) {
 		// Show shiny star if applicable
 		if(pkm.shiny())	drawImageScaled(170 + (69 * WIDE_SCALE), 45, WIDE_SCALE, 1, shiny, true, true);
+		else	drawRectangle(170 + (69 * WIDE_SCALE), 45, shiny.width * WIDE_SCALE, shiny.height, 0, true, true);
 
 		// Print Pokédex number
 		char str[9];


### PR DESCRIPTION
Hi :wave: this is a quick fix to the shiny status display on the topscreen. Previously, selecting a shiny Pokémon would display the little red star but then selecting a non-shiny Pokémon would leave the marker on the screen.


Thank you for this great tool. This is especially useful for my GBA Pokémon games :smile: 